### PR TITLE
Add t1st3 namespace to composer's psr-4 autoload section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
     "phpdocumentor/phpdocumentor": "2.*",
     "phpunit/phpunit": "5.*",
     "sebastian/phpcpd": "2.*"
+  },
+  "autoload": {
+    "psr-4": {
+      "t1st3\\": "src/t1st3/"
+    }
   }
 }


### PR DESCRIPTION
Simple change to enable load t1st2 namespace from composer's autoload file
